### PR TITLE
Expose Recast reference image keyword

### DIFF
--- a/app/launch.py
+++ b/app/launch.py
@@ -8679,6 +8679,7 @@ async def recast_endpoint(request: Request):
     Body: {
         video_path: str, ref_image_path: str,
         target?: str ("who to replace" keyword, default "person"),
+        ref_target?: str (reference-image keyword, default "human character"),
         prompt?: str (describing the new character in the scene helps),
         start_time?: float, end_time?: float  (optional trim),
         model_type?: str (default scail2_14B_fast),
@@ -8697,6 +8698,7 @@ async def recast_endpoint(request: Request):
     if not ref_image_path:
         raise HTTPException(status_code=400, detail=f"Reference image not found: {body.get('ref_image_path')}")
     target = (body.get("target") or "person").strip() or "person"
+    ref_target = (body.get("ref_target") or "human character").strip() or "human character"
     original_video_path = video_path
 
     # Optional trim — outpaint's frame-accurate re-encode pattern. The
@@ -8789,7 +8791,7 @@ async def recast_endpoint(request: Request):
         "sliding_window_size": 81,
         "sliding_window_overlap": 5,
         "settings_version": 2.57,
-        "custom_settings": {"image_ref_keyword_content": "human character"},
+        "custom_settings": {"image_ref_keyword_content": ref_target},
         # UI restore keys for the gallery Edits filter + Load Settings.
         "edit_video_path": original_video_path,
         "edit_start_time": float(trim_start) if trim_start is not None else 0.0,

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -844,6 +844,8 @@ export async function submitRecast(params: {
   ref_image_path: string;
   /** Who to replace, as a SAM3 keyword ("woman", "man in red"). */
   target?: string;
+  /** What to isolate in the reference image ("human character", "red panda"). */
+  ref_target?: string;
   /** Optional scene/character description — a good one helps identity. */
   prompt?: string;
   start_time?: number;

--- a/ui/src/components/Sidebar/RecastControls.tsx
+++ b/ui/src/components/Sidebar/RecastControls.tsx
@@ -21,6 +21,13 @@ export function RecastControls() {
   const setEditVideo = useStore(s => s.setEditVideo)
   const clearEditVideo = useStore(s => s.clearEditVideo)
   const recastTarget = useStore(s => s.editRecastTarget)
+  const refKeyword = useStore(s => {
+    const custom = s.params.custom_settings as Record<string, unknown> | undefined
+    return typeof custom?.image_ref_keyword_content === 'string'
+      ? custom.image_ref_keyword_content
+      : 'human character'
+  })
+  const setParam = useStore(s => s.setParam)
   const refFile = useStore(s => s.editRecastRefFile)
   const refUrl = useStore(s => s.editRecastRefUrl)
   const setEditRecastRef = useStore(s => s.setEditRecastRef)
@@ -187,6 +194,21 @@ export function RecastControls() {
             </button>
           </div>
         )}
+        <label className="text-[10px] text-text-muted uppercase tracking-wider mt-2 mb-1 block">Reference image keyword</label>
+        <input
+          type="text"
+          value={refKeyword}
+          onChange={e => {
+            const custom = { ...(useStore.getState().params.custom_settings || {}) } as Record<string, unknown>
+            custom.image_ref_keyword_content = e.target.value
+            setParam('custom_settings', custom)
+          }}
+          placeholder="human character"
+          className="w-full bg-bg-tertiary border border-border rounded px-2 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent-blue"
+        />
+        <p className="text-[9px] text-text-muted mt-0.5">
+          What to isolate in the new-character image, e.g. &quot;red panda&quot;.
+        </p>
       </div>
 
       <p className="text-[9px] text-text-muted">

--- a/ui/src/components/Sidebar/RecastControls.tsx
+++ b/ui/src/components/Sidebar/RecastControls.tsx
@@ -165,6 +165,27 @@ export function RecastControls() {
         )}
       </div>
 
+      {/* The source-video target and reference-image target are separate
+          detector prompts. Keep them together so the distinction is visible
+          before the user uploads either asset. */}
+      <div className="bg-bg-tertiary/50 border border-border/70 rounded-lg p-2.5">
+        <label className="text-[10px] text-text-muted uppercase tracking-wider mb-1 block">Reference image contains</label>
+        <input
+          type="text"
+          value={refKeyword}
+          onChange={e => {
+            const custom = { ...(useStore.getState().params.custom_settings || {}) } as Record<string, unknown>
+            custom.image_ref_keyword_content = e.target.value
+            setParam('custom_settings', custom)
+          }}
+          placeholder="human character"
+          className="w-full bg-bg-tertiary border border-border rounded px-2 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent-blue"
+        />
+        <p className="text-[9px] text-text-muted mt-1">
+          Describe the subject in the new-character image, e.g. &quot;red panda&quot;.
+        </p>
+      </div>
+
       {/* Reference character image */}
       <div>
         <label className="text-[10px] text-text-muted uppercase tracking-wider mb-1 block">New character</label>
@@ -194,21 +215,6 @@ export function RecastControls() {
             </button>
           </div>
         )}
-        <label className="text-[10px] text-text-muted uppercase tracking-wider mt-2 mb-1 block">Reference image keyword</label>
-        <input
-          type="text"
-          value={refKeyword}
-          onChange={e => {
-            const custom = { ...(useStore.getState().params.custom_settings || {}) } as Record<string, unknown>
-            custom.image_ref_keyword_content = e.target.value
-            setParam('custom_settings', custom)
-          }}
-          placeholder="human character"
-          className="w-full bg-bg-tertiary border border-border rounded px-2 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent-blue"
-        />
-        <p className="text-[9px] text-text-muted mt-0.5">
-          What to isolate in the new-character image, e.g. &quot;red panda&quot;.
-        </p>
       </div>
 
       <p className="text-[9px] text-text-muted">

--- a/ui/src/stores/useStore.ts
+++ b/ui/src/stores/useStore.ts
@@ -3625,6 +3625,10 @@ export const useStore = create<AppState>((set, get) => ({
           video_path: state.editVideoPath,
           ref_image_path: state.editRecastRefPath,
           target: state.editRecastTarget || 'person',
+          ref_target: String(
+            (state.params.custom_settings as Record<string, unknown> | undefined)?.image_ref_keyword_content
+              || 'human character',
+          ).trim() || 'human character',
           ...(promptText ? { prompt: promptText } : {}),
           ...(recastIsScail2 ? {
             model_type: recastModel,


### PR DESCRIPTION
## What changed

- adds a dedicated **Reference image keyword** field to Recast controls
- sends the keyword through the Recast client and request payload
- uses the supplied keyword for SCAIL-2 reference-image masking
- preserves `human character` as the default for existing workflows

## Why

Recast exposed the source-video **Who to replace** keyword, but hard-coded the reference-image detector phrase to `human character`. Non-human references such as a red panda could therefore fail masking with no UI override.

## Impact

Users can describe the subject in the reference image independently from the subject being replaced in the source video. Existing Recast jobs retain their current default behavior.

## Validation

- `npm run build`
- ESLint on the changed UI component and API client
- Python syntax compilation of `app/launch.py`
- `git diff --check`