### PR TITLE
Fix SCAIL-2 attention crashing on GPUs the flash-attn wheel has no kernels for

### DIFF
--- a/app/models/wan/modules/scail2_attention.py
+++ b/app/models/wan/modules/scail2_attention.py
@@ -23,6 +23,84 @@ __all__ = [
     'attention',
 ]
 
+# Upstream SCAIL-2 calls Flash Attention directly.  That ignores the attention
+# backend the user selected and hard fails on GPUs the installed flash-attn
+# wheel carries no kernels for ("no kernel image is available for execution on
+# the device", e.g. SM 8.6 with a wheel built for sm80/sm90 only).  Route
+# through Maestro's shared dispatcher instead, so the dedicated transformer
+# path gets the same backend selection and capability gating as the
+# generalized Wan path.  The vendored implementation below stays as the
+# fallback for standalone / CPU contract-test use.
+_dispatcher = None
+
+
+def _get_dispatcher():
+    global _dispatcher
+    if _dispatcher is None:
+        try:
+            from mmgp import offload
+            from shared.attention import (
+                get_default_attention_mode,
+                pay_attention,
+            )
+        except Exception:
+            _dispatcher = False
+        else:
+            _dispatcher = (pay_attention, get_default_attention_mode, offload)
+    return None if _dispatcher is False else _dispatcher
+
+
+def _shared_attention(
+    dispatcher,
+    q,
+    k,
+    v,
+    q_lens,
+    k_lens,
+    dropout_p,
+    softmax_scale,
+    q_scale,
+    causal,
+    window_size,
+    deterministic,
+    dtype,
+    fa_version,
+):
+    pay_attention, get_default_attention_mode, offload = dispatcher
+    half_dtypes = (torch.float16, torch.bfloat16)
+    assert dtype in half_dtypes
+    out_dtype = q.dtype
+
+    def half(x):
+        return x if x.dtype in half_dtypes else x.to(dtype)
+
+    q, k, v = half(q), half(k), half(v)
+    if q_scale is not None:
+        q = q * q_scale
+
+    # 'pay_attention' reads the selected backend from the offload shared state,
+    # which only the generation loop populates.
+    force_attention = (
+        None if offload.shared_state.get("_attention")
+        else get_default_attention_mode()
+    )
+
+    qkv_list = [q, k, v]
+    del q, k, v
+    x = pay_attention(
+        qkv_list,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        deterministic=deterministic,
+        version=fa_version,
+        q_lens=q_lens,
+        k_lens=k_lens,
+        force_attention=force_attention,
+    )
+    return x.type(out_dtype)
+
 
 def flash_attention(
     q,
@@ -148,6 +226,26 @@ def attention(
     dtype=torch.bfloat16,
     fa_version=None,
 ):
+    if q.device.type == 'cuda':
+        dispatcher = _get_dispatcher()
+        if dispatcher is not None:
+            return _shared_attention(
+                dispatcher,
+                q=q,
+                k=k,
+                v=v,
+                q_lens=q_lens,
+                k_lens=k_lens,
+                dropout_p=dropout_p,
+                softmax_scale=softmax_scale,
+                q_scale=q_scale,
+                causal=causal,
+                window_size=window_size,
+                deterministic=deterministic,
+                dtype=dtype,
+                fa_version=fa_version,
+            )
+
     if (
         q.device.type == 'cuda'
         and (FLASH_ATTN_2_AVAILABLE or FLASH_ATTN_3_AVAILABLE)

--- a/app/shared/attention.py
+++ b/app/shared/attention.py
@@ -195,6 +195,36 @@ def sdpa_wrapper(
     return o
 
 
+_flash_attn_kernels = None
+
+
+def flash_attn_kernels_available():
+    """Whether the installed flash-attn wheel carries kernels for this GPU.
+
+    flash-attn imports successfully on any device, but a wheel only ships
+    cubins for the architectures it was built against.  Launching on any other
+    architecture fails with "no kernel image is available for execution on the
+    device" -- for instance the common sm80/sm90 Windows wheels on an SM 8.6
+    card.  A wheel's architecture list cannot be read back, so probe once with
+    a minimal varlen call and cache the verdict.
+    """
+    global _flash_attn_kernels
+    if _flash_attn_kernels is None:
+        if flash_attn is None or not torch.cuda.is_available():
+            _flash_attn_kernels = False
+        else:
+            try:
+                probe = torch.zeros(1, 1, 32, dtype=torch.float16, device="cuda")
+                cu_seqlens = torch.tensor([0, 1], dtype=torch.int32, device="cuda")
+                flash_attn.flash_attn_varlen_func(
+                    probe, probe, probe, cu_seqlens, cu_seqlens, 1, 1)
+                torch.cuda.synchronize()
+                _flash_attn_kernels = True
+            except Exception:
+                _flash_attn_kernels = False
+    return _flash_attn_kernels
+
+
 def get_attention_modes():
     ret = ["sdpa", "auto"]
     if flash_attn != None:
@@ -229,6 +259,9 @@ def get_supported_attention_modes():
     if major < 7 or not triton_installed:
         if "sage" in ret:
             ret.remove("sage")
+
+    if "flash" in ret and not flash_attn_kernels_available():
+        ret.remove("flash")
 
     return ret
 


### PR DESCRIPTION
## Problem

Generation on the dedicated SCAIL-2 transformer path dies at the first attention call:

```
File "app/models/wan/modules/scail2_attention.py", line 83, in flash_attention
  v = half(torch.cat([u[:v] for u, v in zip(v, k_lens)]))
...
File "flash_attn/flash_attn_interface.py", line 170, in _flash_attn_varlen_forward
  out, softmax_lse, S_dmask, rng_state = flash_attn_gpu.varlen_fwd(
RuntimeError: CUDA error: no kernel image is available for execution on the device
```

Reproduced on an RTX 3060 (SM 8.6), Windows, `attention_mode: "auto"` (which resolves to `sage2`). Every task in the queue failed identically.

## Root cause

`app/models/wan/modules/scail2_attention.py` calls `flash_attn` directly whenever the package merely *imports*, bypassing `shared.attention.pay_attention`. That has two independent consequences:

1. **The user's selected attention backend is silently ignored** on this path, unlike every other model path. Even with `auto` → `sage2`, SCAIL-2 forced Flash Attention.
2. **It crashes on any GPU the installed wheel has no kernels for.** Because the call was lowered into a `torch.compile` graph, the failure surfaced from inside inductor output code rather than at the call site, which makes it hard to read.

A second, related gap: `get_supported_attention_modes()` advertises `flash` whenever `flash_attn` imports. Importability says nothing about whether the wheel carries cubins for the running device, so `flash` shows as supported in the UI and then fails at generation time.

## Changes

**`Route SCAIL-2 attention through the shared dispatcher`** — CUDA calls now go through `pay_attention`, inheriting the same backend selection, capability gating and `@torch.compiler.disable` treatment as the generalized Wan path. The vendored implementation stays as the fallback for standalone/CPU contract-test use, and falls back to `get_default_attention_mode()` when the offload shared state has not been populated by the generation loop.

**`Gate flash attention on the wheel having kernels for this GPU`** — a wheel's architecture list can't be read back at runtime, so probe once with a minimal varlen call and cache the verdict, then drop `flash` alongside the existing `sage`/`sage2`/`sage3` capability removals. Installed-but-unsupported already renders as `(NOT SUPPORTED)` and aborts with a helpful message, so no caller changes were needed.

The two commits are independent and can be taken separately.

## Verification

On SM 8.6, against a float32 SDPA reference at the 14B self-attention shape `(1, 4096, 40, 128)` with padded keys (`k_lens=300` of 512):

| backend | max abs error vs reference |
|---|---|
| `sdpa` | 1.98e-3 (bf16 rounding) |
| `sage2` | 3.6e-2 (its INT8 quantization) |

Cross-attention (`k_lens=None`), the CPU path, and `torch.compile` all verified. 124 SCAIL-2 contract tests pass (`tests/test_scail2_dedicated_model.py`, `tests/test_scail2_workflows.py`).

Probe cost: ~0.46s once including CUDA warmup, 0.002s cached. A failed launch returns `cudaErrorNoKernelImageForDevice` at launch and is **not** sticky — verified that a 2048² matmul and a full 14B-shape `sage2` attention both run normally in the same process afterwards.

## Separate issue for maintainers: the pinned Windows wheel is Ada-only

Not addressed in this PR, but it is the underlying reason the crash was reachable at all. `torch.js:79` pins the Windows flash-attn wheel under a comment reading *"Preserve the known-good public runtime for RTX 20/30/40 systems"*. That wheel contains only `sm_89` cubins:

```
$ cuobjdump -lelf flash_attn_2_cuda.cp310-win_amd64.pyd | grep -oE "sm_[0-9]+" | sort -u
sm_89
```

`sm_89` is Ada — RTX 40 only. Every RTX 30 (`sm_86`) and RTX 20 (`sm_75`) install therefore receives a flash-attn that imports cleanly, advertises itself in the UI, and cannot execute a single kernel. The comment on lines 77–78 shows a symptom of this was already chased once on RTX 30 and "fixed" by swapping wheels; the replacement has the same defect.

The changes in this PR make that failure graceful rather than fatal, but a real fix means sourcing an `sm_86`-capable wheel or selecting per-architecture in `torch.js` (which already branches on `cudaArch`). I did not guess at a replacement wheel URL since I have no way to verify its cubin set from here.
