### PR TITLE
Make the remote OpenAI-compatible LLM provider usable (401, then 400)

### DIFF
--- a/app/launch.py
+++ b/app/launch.py
@@ -6281,6 +6281,11 @@ def get_services_config():
         "llm_device": services.get("llm_device", _llm_default_device()),
         "llm_provider": provider,
         "llm_remote_url": services.get("llm_remote_url", ""),
+        # Hosted OpenAI-compatible endpoints (as opposed to a LAN LM Studio /
+        # Ollama box) require a bearer token. Kept separate from the OpenAI
+        # key so switching providers doesn't send the wrong credential.
+        "llm_remote_api_key": _mask_key(services.get("llm_remote_api_key", "")),
+        "llm_remote_api_key_set": bool(services.get("llm_remote_api_key", "")),
         "enhance_llm_model_id": services.get("enhance_llm_model_id", ""),
         "enhance_llm_device": services.get("enhance_llm_device", "cuda"),
         "google_api_key": _mask_key(services.get("google_api_key", "")),
@@ -6367,6 +6372,7 @@ async def update_services_config(request: Request):
 
     ALLOWED_KEYS = {
         "llm_model_id", "llm_device", "llm_provider", "llm_remote_url",
+        "llm_remote_api_key",
         "enhance_llm_model_id", "enhance_llm_device",
         "google_api_key", "openai_api_key", "anthropic_api_key",
         "use_director_v2", "nsfw_mode", "nsfw_accepted_at", "director_prompt_polish",
@@ -6955,11 +6961,7 @@ async def llm_load(request: Request):
     device = body.get("device", services.get("llm_device", _llm_default_device()))
     provider = body.get("provider", services.get("llm_provider", "local"))
     remote_url = body.get("remote_url", services.get("llm_remote_url", ""))
-    api_key = ""
-    if provider == "openai":
-        api_key = services.get("openai_api_key", "")
-    elif provider == "anthropic":
-        api_key = services.get("anthropic_api_key", "")
+    api_key = llm_service.provider_api_key(provider, services)
 
     try:
         llm_service.load_model(model_id=model_id, device=device, provider=provider, remote_url=remote_url, api_key=api_key)
@@ -6984,11 +6986,7 @@ def list_llm_models(provider: str = ""):
     services = wgp.server_config.get("services", {})
     p = provider or services.get("llm_provider", "local")
     remote_url = services.get("llm_remote_url", "")
-    api_key = ""
-    if p == "openai":
-        api_key = services.get("openai_api_key", "")
-    elif p == "anthropic":
-        api_key = services.get("anthropic_api_key", "")
+    api_key = llm_service.provider_api_key(p, services)
     return {"models": llm_service.get_available_models(provider=p, remote_url=remote_url, api_key=api_key)}
 
 
@@ -7007,11 +7005,7 @@ def _ensure_llm_loaded():
     desired_device = services.get("llm_device", _llm_default_device())
     desired_provider = services.get("llm_provider", "local")
     desired_remote_url = services.get("llm_remote_url", "")
-    desired_api_key = ""
-    if desired_provider == "openai":
-        desired_api_key = services.get("openai_api_key", "")
-    elif desired_provider == "anthropic":
-        desired_api_key = services.get("anthropic_api_key", "")
+    desired_api_key = llm_service.provider_api_key(desired_provider, services)
 
     if llm_service.is_loaded():
         status = llm_service.get_status()

--- a/app/services/director_pipeline.py
+++ b/app/services/director_pipeline.py
@@ -4694,11 +4694,7 @@ def _ensure_llm_loaded(params: dict):
     desired_device = params.get("llm_device") or services_cfg.get("llm_device", "cpu")
     desired_provider = params.get("llm_provider") or services_cfg.get("llm_provider", "local")
     desired_remote_url = services_cfg.get("llm_remote_url", "")
-    desired_api_key = ""
-    if desired_provider == "openai":
-        desired_api_key = services_cfg.get("openai_api_key", "")
-    elif desired_provider == "anthropic":
-        desired_api_key = services_cfg.get("anthropic_api_key", "")
+    desired_api_key = llm_service.provider_api_key(desired_provider, services_cfg)
 
     # Free GPU memory before running a local CUDA LLM. Director planning
     # fires right after image edits / audio analysis: memory profiles keep

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -613,6 +613,42 @@ def provider_api_key(provider: str, services: dict) -> str:
     return services.get(setting, "") if setting else ""
 
 
+#: Body fields the OpenAI chat-completions API defines. Everything else in
+#: our payloads is a llama.cpp sampling extension.
+_OPENAI_CHAT_FIELDS = frozenset({
+    "messages", "model", "max_tokens", "max_completion_tokens", "temperature",
+    "top_p", "n", "stream", "stream_options", "stop", "presence_penalty",
+    "frequency_penalty", "logit_bias", "logprobs", "top_logprobs", "seed",
+    "response_format", "tools", "tool_choice", "user",
+})
+
+
+def _finalize_payload(payload: dict) -> dict:
+    """Adapt a llama-server payload to whichever provider is active.
+
+    Payloads are built in llama-server's dialect: it serves exactly one
+    model, so no "model" field is needed, and it accepts llama.cpp sampling
+    extensions such as top_k, min_p, repeat_penalty and cache_prompt.
+
+    Remote OpenAI-compatible endpoints need the opposite treatment. "model"
+    is required by the spec -- a gateway fronting several models cannot
+    route without it -- and strict gateways reject unknown body fields
+    outright, so a request carrying cache_prompt comes back 400 Bad Request
+    with no indication of which field was at fault.
+    """
+    if _provider == "local":
+        return payload
+    prepared = {k: v for k, v in payload.items() if k in _OPENAI_CHAT_FIELDS}
+    dropped = sorted(set(payload) - set(prepared))
+    if dropped:
+        print(
+            f"[LLM] Dropped {len(dropped)} llama.cpp-only field(s) not accepted by "
+            f"provider={_provider}: {', '.join(dropped)}"
+        )
+    prepared["model"] = _model_id
+    return prepared
+
+
 def _server_url() -> str:
     if _provider in ("remote", "openai") and _remote_url:
         return _remote_url.rstrip("/")
@@ -1462,8 +1498,23 @@ def _diagnose_llm_request_failure(exc: Exception) -> "RuntimeError":
         return RuntimeError(
             f"LLM request failed: {exc}\nRecent llama-server output:\n{tail}"
         )
-    # Remote provider — a real network/timeout issue.
-    return RuntimeError(f"LLM request failed: {exc}")
+    # Remote provider — a network/timeout issue, or the endpoint rejecting
+    # the request. requests' HTTPError stringifies to the status line alone,
+    # so a 4xx arrives with no hint of what the gateway objected to. Quote
+    # its body: that is where "unknown parameter" / "model not found" /
+    # "insufficient quota" actually live.
+    detail = ""
+    response = getattr(exc, "response", None)
+    if response is not None:
+        try:
+            body = (response.text or "").strip()
+        except Exception:
+            body = ""
+        if body:
+            if len(body) > 800:
+                body = body[:800] + "... (truncated)"
+            detail = f"\nEndpoint response: {body}"
+    return RuntimeError(f"LLM request failed: {exc}{detail}")
 
 
 def _unload_inner():
@@ -1659,7 +1710,7 @@ def generate(
     try:
         resp = requests.post(
             f"{_server_url()}/v1/chat/completions",
-            json=payload,
+            json=_finalize_payload(payload),
             headers=_api_headers(),
             # (connect, read): fail fast if the server socket is gone;
             # allow a long read for actual generation.
@@ -1868,7 +1919,7 @@ def generate_streaming(
     try:
         resp = requests.post(
             f"{_server_url()}/v1/chat/completions",
-            json=payload,
+            json=_finalize_payload(payload),
             headers=_api_headers(),
             timeout=(10, 600),
             stream=True,

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -592,6 +592,27 @@ def get_model_dir() -> str:
     return d
 
 
+#: Which services-config entry holds the credential for each provider.
+#: "local" is absent on purpose — llama-server needs no key.
+PROVIDER_API_KEY_SETTING = {
+    "remote": "llm_remote_api_key",
+    "openai": "openai_api_key",
+    "anthropic": "anthropic_api_key",
+}
+
+
+def provider_api_key(provider: str, services: dict) -> str:
+    """Resolve the API key a provider should authenticate with.
+
+    Callers used to inline this mapping, and every copy omitted "remote" --
+    so hosted OpenAI-compatible endpoints were called with no Authorization
+    header and answered 401. Keep the mapping here, next to the code that
+    builds the headers, so a new provider only has to be added once.
+    """
+    setting = PROVIDER_API_KEY_SETTING.get(provider)
+    return services.get(setting, "") if setting else ""
+
+
 def _server_url() -> str:
     if _provider in ("remote", "openai") and _remote_url:
         return _remote_url.rstrip("/")

--- a/tests/test_llm_provider_api_key.py
+++ b/tests/test_llm_provider_api_key.py
@@ -1,0 +1,140 @@
+"""Contract tests for LLM provider credential resolution.
+
+Every caller that loads an LLM used to inline its own provider -> key
+mapping, and all four copies omitted "remote". Hosted OpenAI-compatible
+endpoints were therefore called with no Authorization header and answered
+401 Unauthorized. These tests pin the shared mapping so a new provider
+cannot be half-wired again.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_APP = os.path.join(_ROOT, "app")
+if _APP not in sys.path:
+    sys.path.insert(0, _APP)
+
+
+class TestProviderApiKey(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from services import llm_service
+        except ImportError as exc:
+            raise unittest.SkipTest("llm_service dependencies unavailable") from exc
+        cls.llm_service = llm_service
+        cls.services = {
+            "llm_remote_api_key": "sk-remote",
+            "openai_api_key": "sk-openai",
+            "anthropic_api_key": "sk-anthropic",
+        }
+
+    def test_remote_provider_resolves_its_own_key(self):
+        """The regression this suite exists for."""
+        self.assertEqual(
+            self.llm_service.provider_api_key("remote", self.services),
+            "sk-remote",
+        )
+
+    def test_each_provider_gets_its_own_credential(self):
+        for provider, expected in (
+            ("remote", "sk-remote"),
+            ("openai", "sk-openai"),
+            ("anthropic", "sk-anthropic"),
+        ):
+            with self.subTest(provider=provider):
+                self.assertEqual(
+                    self.llm_service.provider_api_key(provider, self.services),
+                    expected,
+                )
+
+    def test_local_provider_sends_no_credential(self):
+        """llama-server needs no key and must never receive one."""
+        self.assertEqual(self.llm_service.provider_api_key("local", self.services), "")
+
+    def test_unknown_provider_is_empty_not_an_error(self):
+        for provider in ("", "bogus", None):
+            with self.subTest(provider=provider):
+                self.assertEqual(
+                    self.llm_service.provider_api_key(provider, self.services), ""
+                )
+
+    def test_unset_key_is_empty(self):
+        """An unconfigured key yields no header rather than KeyError."""
+        for provider in self.llm_service.PROVIDER_API_KEY_SETTING:
+            with self.subTest(provider=provider):
+                self.assertEqual(self.llm_service.provider_api_key(provider, {}), "")
+
+    def test_every_mapped_setting_is_persistable(self):
+        """Each mapped setting must survive a settings write.
+
+        A key the settings endpoint refuses to store would resolve to ""
+        forever, which is exactly how this bug presented to users.
+        """
+        launch_source = os.path.join(_APP, "launch.py")
+        with open(launch_source, encoding="utf-8") as handle:
+            source = handle.read()
+
+        # launch.py declares several ALLOWED_KEYS allowlists (performance,
+        # services, ...). A credential may live in any of them, so union them.
+        allowed = ""
+        marker = "ALLOWED_KEYS = {"
+        cursor = source.find(marker)
+        self.assertNotEqual(cursor, -1, "no ALLOWED_KEYS allowlist found in launch.py")
+        while cursor != -1:
+            allowed += source[cursor:source.index("}", cursor)]
+            cursor = source.find(marker, cursor + 1)
+
+        for setting in self.llm_service.PROVIDER_API_KEY_SETTING.values():
+            with self.subTest(setting=setting):
+                self.assertIn(f'"{setting}"', allowed)
+
+
+class TestApiHeaders(unittest.TestCase):
+    """The headers built from a resolved key."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from services import llm_service
+        except ImportError as exc:
+            raise unittest.SkipTest("llm_service dependencies unavailable") from exc
+        cls.llm_service = llm_service
+
+    def setUp(self):
+        self.saved = (
+            self.llm_service._provider,
+            self.llm_service._api_key,
+        )
+
+    def tearDown(self):
+        self.llm_service._provider, self.llm_service._api_key = self.saved
+
+    def _headers_for(self, provider, key):
+        self.llm_service._provider = provider
+        self.llm_service._api_key = key
+        return self.llm_service._api_headers()
+
+    def test_remote_sends_bearer_token(self):
+        headers = self._headers_for("remote", "sk-remote")
+        self.assertEqual(headers.get("Authorization"), "Bearer sk-remote")
+
+    def test_anthropic_uses_its_own_header_scheme(self):
+        headers = self._headers_for("anthropic", "sk-anthropic")
+        self.assertEqual(headers.get("x-api-key"), "sk-anthropic")
+        self.assertNotIn("Authorization", headers)
+
+    def test_local_sends_no_auth(self):
+        self.assertNotIn("Authorization", self._headers_for("local", ""))
+
+    def test_remote_without_key_sends_no_auth(self):
+        """LM Studio / Ollama on the LAN need no credential."""
+        self.assertNotIn("Authorization", self._headers_for("remote", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_remote_payload.py
+++ b/tests/test_llm_remote_payload.py
@@ -1,0 +1,176 @@
+"""Contract tests for remote OpenAI-compatible request payloads.
+
+Payloads are authored in llama-server's dialect: it serves one model, so
+no "model" field is sent, and it accepts llama.cpp sampling extensions.
+Remote endpoints need the opposite -- "model" is required by the spec and
+strict gateways reject unknown fields with 400 Bad Request. These tests
+pin the translation between the two.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_APP = os.path.join(_ROOT, "app")
+if _APP not in sys.path:
+    sys.path.insert(0, _APP)
+
+
+def _llama_style_payload():
+    """What generate() builds for a vision-enabled enhance call."""
+    return {
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                {"type": "text", "text": "describe"},
+            ],
+        }],
+        "max_tokens": 1024,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "stop": ["<think>"],
+        "seed": 42,
+        # llama.cpp-only below this line
+        "cache_prompt": False,
+        "top_k": 64,
+        "min_p": 0.05,
+        "repeat_penalty": 1.1,
+        "repeat_last_n": 64,
+        "enable_thinking": False,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+class TestFinalizePayload(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from services import llm_service
+        except ImportError as exc:
+            raise unittest.SkipTest("llm_service dependencies unavailable") from exc
+        cls.llm_service = llm_service
+
+    def setUp(self):
+        self.saved = (self.llm_service._provider, self.llm_service._model_id)
+
+    def tearDown(self):
+        self.llm_service._provider, self.llm_service._model_id = self.saved
+
+    def _finalize(self, provider, payload, model_id="claude-opus-5"):
+        self.llm_service._provider = provider
+        self.llm_service._model_id = model_id
+        return self.llm_service._finalize_payload(payload)
+
+    def test_local_payload_is_untouched(self):
+        """llama-server wants its own dialect — do not rewrite it."""
+        payload = _llama_style_payload()
+        self.assertEqual(self._finalize("local", dict(payload)), payload)
+
+    def test_remote_request_carries_a_model(self):
+        """Required by the OpenAI spec; a gateway cannot route without it."""
+        out = self._finalize("remote", _llama_style_payload())
+        self.assertEqual(out.get("model"), "claude-opus-5")
+
+    def test_remote_drops_llama_cpp_extensions(self):
+        out = self._finalize("remote", _llama_style_payload())
+        for field in (
+            "cache_prompt", "top_k", "min_p", "repeat_penalty",
+            "repeat_last_n", "enable_thinking", "chat_template_kwargs",
+        ):
+            with self.subTest(field=field):
+                self.assertNotIn(field, out)
+
+    def test_remote_keeps_standard_fields(self):
+        source = _llama_style_payload()
+        out = self._finalize("remote", dict(source))
+        for field in ("messages", "max_tokens", "temperature", "top_p", "stop", "seed"):
+            with self.subTest(field=field):
+                self.assertEqual(out[field], source[field])
+
+    def test_multimodal_content_survives(self):
+        """The image part must reach a vision endpoint intact."""
+        out = self._finalize("remote", _llama_style_payload())
+        parts = out["messages"][0]["content"]
+        self.assertEqual(parts[0]["type"], "image_url")
+        self.assertEqual(parts[0]["image_url"]["url"], "data:image/png;base64,AAAA")
+        self.assertEqual(parts[1]["text"], "describe")
+
+    def test_openai_provider_translated_too(self):
+        """The hosted OpenAI API is as strict as any other gateway."""
+        out = self._finalize("openai", _llama_style_payload(), model_id="gpt-5")
+        self.assertEqual(out.get("model"), "gpt-5")
+        self.assertNotIn("cache_prompt", out)
+
+    def test_caller_payload_not_mutated(self):
+        """Translation must not corrupt the caller's dict."""
+        payload = _llama_style_payload()
+        self._finalize("remote", payload)
+        self.assertIn("cache_prompt", payload)
+        self.assertNotIn("model", payload)
+
+    def test_every_kept_field_is_a_known_openai_field(self):
+        out = self._finalize("remote", _llama_style_payload())
+        self.assertTrue(set(out).issubset(self.llm_service._OPENAI_CHAT_FIELDS))
+
+
+class TestRemoteFailureDetail(unittest.TestCase):
+    """A rejected request must quote the endpoint's explanation."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import requests
+            from services import llm_service
+        except ImportError as exc:
+            raise unittest.SkipTest("llm_service dependencies unavailable") from exc
+        cls.requests = requests
+        cls.llm_service = llm_service
+
+    def setUp(self):
+        self.saved = (self.llm_service._provider, self.llm_service._process)
+        self.llm_service._provider = "remote"
+        self.llm_service._process = None
+
+    def tearDown(self):
+        self.llm_service._provider, self.llm_service._process = self.saved
+
+    def _error_for(self, status, body):
+        response = self.requests.Response()
+        response.status_code = status
+        response.url = "https://api.example.com/v1/chat/completions"
+        response._content = body
+        try:
+            response.raise_for_status()
+        except self.requests.exceptions.RequestException as exc:
+            return self.llm_service._diagnose_llm_request_failure(exc)
+        self.fail("expected raise_for_status to raise")
+
+    def test_response_body_is_quoted(self):
+        message = str(self._error_for(
+            400, b'{"error":{"message":"Unrecognized request argument: cache_prompt"}}'
+        ))
+        self.assertIn("Unrecognized request argument: cache_prompt", message)
+
+    def test_long_body_is_truncated(self):
+        message = str(self._error_for(400, b"x" * 5000))
+        self.assertIn("truncated", message)
+        self.assertLess(len(message), 1200)
+
+    def test_empty_body_adds_no_noise(self):
+        message = str(self._error_for(500, b""))
+        self.assertIn("LLM request failed", message)
+        self.assertNotIn("Endpoint response", message)
+
+    def test_connection_error_without_response_is_handled(self):
+        """No response object at all — must not raise while building the error."""
+        exc = self.requests.exceptions.ConnectionError("connection refused")
+        message = str(self.llm_service._diagnose_llm_request_failure(exc))
+        self.assertIn("connection refused", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/src/components/SettingsDrawer/ServicesSettingsPanel.tsx
+++ b/ui/src/components/SettingsDrawer/ServicesSettingsPanel.tsx
@@ -703,6 +703,25 @@ export function ServicesSettingsPanel() {
       <div className="space-y-4">
         <h3 className="text-[11px] text-text-secondary uppercase tracking-wider font-medium">API Keys</h3>
 
+        {/* Shown only while the remote provider is selected, and deliberately
+            not gated behind show_experimental: without this key a hosted
+            OpenAI-compatible endpoint answers 401, so it isn't optional for
+            the users who need it. */}
+        {isRemote && (
+          <>
+            <ApiKeyField
+              label="Remote OpenAI-Compatible API Key"
+              maskedValue={servicesConfig.llm_remote_api_key}
+              isSet={servicesConfig.llm_remote_api_key_set}
+              onSave={val => updateConfig({ llm_remote_api_key: val })}
+            />
+            <p className="text-[10px] text-text-muted -mt-2">
+              Sent as an Authorization: Bearer header to the Server URL set above. Leave unset
+              for local servers such as LM Studio or Ollama, which usually need no key.
+            </p>
+          </>
+        )}
+
         {servicesConfig.show_experimental && (
           <>
             <p className="text-[10px] text-text-muted">

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -619,6 +619,8 @@ export interface ServicesConfig {
   llm_device: string
   llm_provider: string
   llm_remote_url: string
+  llm_remote_api_key: string
+  llm_remote_api_key_set: boolean
   enhance_llm_model_id: string
   enhance_llm_device: string
   google_api_key: string


### PR DESCRIPTION
## Problem

Settings → LLM Configuration → **Remote OpenAI-Compatible (LM Studio, etc.)** offers no field for an API key, and the backend sends none. Any hosted OpenAI-compatible endpoint that requires a bearer token fails:

```
Prompt enhancement failed: LLM request failed:
401 Client Error: Unauthorized for url: https://api.<provider>.dev/v1/chat/completions
```

Filling in the **OpenAI API Key** or **Anthropic API Key** fields doesn't help — those are only consulted when their own provider is selected, so the request still goes out unauthenticated.

## Root cause

`llm_service` already builds the right header for this provider:

```python
if _provider in ("remote", "openai", "anthropic") and _api_key:
    ...
    headers["Authorization"] = f"Bearer {_api_key}"
```

It simply never received a key. Four call sites each inlined their own provider → setting mapping, and **every copy handled only `openai` and `anthropic`**:

| call site | file |
|---|---|
| `llm_load` | `app/launch.py` |
| `list_llm_models` | `app/launch.py` |
| `_ensure_llm_loaded` | `app/launch.py` |
| `_ensure_llm_loaded` | `app/services/director_pipeline.py` |

Each fell through to `api_key = ""` for `remote`. There was also no setting to hold such a key in the first place.

## Changes

**Backend** — replace the four inlined copies with a single `llm_service.provider_api_key(provider, services)`, living next to the code that builds the headers so a new provider only has to be registered once. Add a `llm_remote_api_key` setting that `remote` resolves to, exposed masked through the services config endpoint and added to the settings allowlist.

Keeping it distinct from `openai_api_key` is deliberate: a shared field would send your OpenAI credential to whatever third-party host is configured as the remote URL when you switch providers.

**UI** — a **Remote OpenAI-Compatible API Key** field in the API Keys section, rendered while that provider is selected and deliberately *not* gated behind `show_experimental`; without it the provider returns 401, so it isn't a power-user extra. The Server URL field already existed and is unchanged.

**Unchanged behaviour** — LM Studio, Ollama and other LAN servers that need no auth keep working with the key left unset: no key still means no `Authorization` header. The `local` provider can never receive a credential, since `local` is absent from the mapping by design.

## Tests

New `tests/test_llm_provider_api_key.py` (10 cases):

- each provider resolves its own credential, `remote` included
- `local` never receives a credential
- unknown/empty provider degrades to `""` rather than raising
- an unset key yields `""`, not `KeyError`
- header construction: bearer for remote/openai, `x-api-key` + version for anthropic, none for local, none for remote-without-key
- every mapped setting appears in an `ALLOWED_KEYS` allowlist — a setting the settings endpoint refuses to store would resolve to `""` forever, which is precisely how this bug reached users

Full suite passes: **873 tests, OK**. UI passes `tsc --noEmit` and `npm run build` clean.

## Verification

With the key set, the outgoing headers are now:

```
{'Content-Type': 'application/json', 'Authorization': 'Bearer sk-r...'}
```

and with the provider left on `local`, unchanged:

```
{'Content-Type': 'application/json'}
```

---

# Second commit: speaking OpenAI dialect

With a credential finally reaching the endpoint, the next request came back **400 Bad Request**. Same underlying shape of problem: payloads are authored in llama-server's dialect and posted verbatim to a foreign server.

**No `model` field.** llama-server serves exactly one model, so the OpenAI-compatible path never sent one — only the native Anthropic path did. The spec requires it, and a gateway fronting several models cannot route without it.

**llama.cpp sampling extensions.** `cache_prompt` goes out on every call, `_apply_model_defaults` adds `top_k` / `min_p` / `repeat_penalty` / `repeat_last_n`, and thinking-capable models add `enable_thinking` + `chat_template_kwargs`. llama-server accepts all of it; strict gateways reject unknown body fields outright.

`_finalize_payload()` now translates at the boundary — local payloads pass through untouched, remote ones keep only spec-defined fields and get the configured model stamped in. Multimodal content is preserved, so vision requests still carry their images. Both `chat/completions` call sites route through it; the two native Anthropic posts keep their own format.

For a vision enhance call the translation drops 7 fields:

```
[LLM] Dropped 7 llama.cpp-only field(s) not accepted by provider=remote:
cache_prompt, chat_template_kwargs, enable_thinking, min_p, repeat_last_n, repeat_penalty, top_k
```

**Error reporting.** `requests`' `HTTPError` stringifies to the status line alone, so this failure reached the user as a bare `400 Bad Request` while the gateway's own explanation was discarded. Rejections now quote the response body (truncated at 800 chars):

```
LLM request failed: 400 Client Error: Bad Request for url: .../v1/chat/completions
Endpoint response: {"error":{"message":"Unrecognized request argument: cache_prompt", ...}}
```

`tests/test_llm_remote_payload.py` adds 12 cases: local payloads untouched, model stamped, extensions dropped, standard fields and multimodal content preserved, the caller's dict not mutated, every kept field spec-defined, and error detail surfaced / truncated / absent when there is no body.

Full suite passes: **887 tests, OK**.
