### PR TITLE
Keep the SAM 3 service on the numpy 1.x ABI

### DIFF
--- a/app/services/sam/requirements.txt
+++ b/app/services/sam/requirements.txt
@@ -3,8 +3,13 @@
 # Note: torch/torchvision installed separately from cu128 index
 
 # SAM 3 core deps
+# NOTE: sam3's pyproject.toml pins numpy<2. Every pin below that caps a version
+# (numpy, opencv-python-headless, scipy) exists to stay on the numpy 1.x ABI --
+# newer releases of those packages require numpy>=2 and will silently upgrade it,
+# breaking sam3 at import time. This env is isolated from Maestro's app/env
+# (which uses numpy 2.x), so these caps do not affect the main app.
 timm>=1.0.17
-numpy>=2
+numpy>=1.26,<2
 tqdm
 ftfy==6.1.1
 regex
@@ -17,7 +22,7 @@ psutil
 einops
 pycocotools
 decord
-opencv-python-headless
+opencv-python-headless<4.10
 
 # Triton (platform-specific)
 triton-windows; sys_platform == 'win32'
@@ -28,5 +33,5 @@ xformers
 fastapi>=0.115.0
 uvicorn>=0.34.0
 Pillow>=10.0
-scipy
+scipy<1.16
 ninja


### PR DESCRIPTION
## Problem

`app/services/sam/requirements.txt` requests `numpy>=2`, but sam3's own `pyproject.toml` pins `numpy<2`. A fresh `sam_install.js` run therefore builds a SAM environment where sam3 raises at import time.

## Fix

Pinning numpy alone is not sufficient — current releases of `opencv-python-headless` and `scipy` both require `numpy>=2` and quietly pull it back in as a transitive dependency, undoing the pin. This caps all three together so the resolver stays on the numpy 1.x ABI:

- `numpy>=2` → `numpy>=1.26,<2`
- `opencv-python-headless` → `opencv-python-headless<4.10`
- `scipy` → `scipy<1.16`

A comment above the block records why each cap exists, so a future dependency bump doesn't silently reintroduce the break.

## Scope

This file describes the isolated Python 3.12 conda env that `sam_install.js` creates for the SAM microservice. Maestro's main `app/env` is untouched and stays on numpy 2.x, so nothing outside the SAM service is affected. Users who already have a working `app/services/sam/env` are unaffected until the env is rebuilt.

## Testing

- `python scripts/verify_clean_repo.py` — PASS
- `python -m compileall -q app/services app/launch.py scripts` — PASS
- UI build not run: this change touches no file under `ui/`.

Branched from `811f0f3` (Release v1.9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
