### PR TITLE
Fix MiniMax Music3 fallback KV cache dtype mismatch

### DIFF
--- a/app/shared/llm_engines/nanovllm/layers/attention.py
+++ b/app/shared/llm_engines/nanovllm/layers/attention.py
@@ -262,6 +262,23 @@ def store_kvcache(
     flat_v_cache[slot_ids] = value[valid_mask]
 
 
+def _align_with_kv_cache_dtype(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Keep fallback attention inputs compatible with their cache storage."""
+    if q.dtype != k_cache.dtype:
+        q = q.to(dtype=k_cache.dtype)
+    if k.dtype != k_cache.dtype:
+        k = k.to(dtype=k_cache.dtype)
+    if v.dtype != v_cache.dtype:
+        v = v.to(dtype=v_cache.dtype)
+    return q, k, v
+
+
 class Attention(nn.Module):
 
     def __init__(
@@ -285,6 +302,14 @@ class Attention(nn.Module):
         context = get_context()
         k_cache, v_cache = self.k_cache, self.v_cache
         if k_cache.numel() and v_cache.numel():
+            if not self.use_triton_kv_cache:
+                q, k, v = _align_with_kv_cache_dtype(
+                    q,
+                    k,
+                    v,
+                    k_cache,
+                    v_cache,
+                )
             store_kvcache(k, v, k_cache, v_cache, context.slot_mapping, use_triton_kv_cache=self.use_triton_kv_cache)
         if context.is_prefill:
             if context.block_tables is not None:    # prefix cache

--- a/tests/test_minimax_music3.py
+++ b/tests/test_minimax_music3.py
@@ -9,6 +9,7 @@ import math
 import os
 from pathlib import Path
 import re
+import sys
 import types
 import unittest
 
@@ -170,6 +171,17 @@ def _load_engine_resolver(*, vllm_supported: bool):
     return namespace["resolve_lm_decoder_engine"]
 
 
+def _load_nanovllm_attention_runtime():
+    app_path = str(_APP)
+    if app_path not in sys.path:
+        sys.path.insert(0, app_path)
+    from shared.llm_engines.cudagraph_kit import CUDAGraphRunner
+    from shared.llm_engines.nanovllm.layers.attention import Attention
+    from shared.llm_engines.nanovllm.utils.context import reset_context, set_context
+
+    return Attention, CUDAGraphRunner, set_context, reset_context
+
+
 class MiniMaxMusic3Tests(unittest.TestCase):
     def test_default_definition_is_visible_and_license_aware(self):
         default = json.loads(_read(_DEFAULT))
@@ -221,6 +233,115 @@ class MiniMaxMusic3Tests(unittest.TestCase):
         self.assertEqual(without_flash_attention("", available), "cg")
         self.assertEqual(without_flash_attention("vllm", available), "cg")
         self.assertEqual(with_flash_attention("", available), "vllm")
+
+    @unittest.skipUnless(
+        importlib.util.find_spec("torch") is not None,
+        "PyTorch is required for KV-cache dtype regression coverage",
+    )
+    def test_sdpa_cache_normalizes_float32_quanto_outputs_to_bfloat16(self):
+        import torch
+
+        (
+            Attention,
+            CUDAGraphRunner,
+            set_context,
+            reset_context,
+        ) = _load_nanovllm_attention_runtime()
+        devices = [torch.device("cpu")]
+        if torch.cuda.is_available():
+            devices.append(torch.device("cuda"))
+
+        for device in devices:
+            with self.subTest(device=device.type):
+                def randn(shape):
+                    return torch.randn(
+                        shape,
+                        device=device,
+                        dtype=torch.float32,
+                    )
+
+                def int_tensor(values):
+                    return torch.tensor(
+                        values,
+                        device=device,
+                        dtype=torch.int32,
+                    )
+
+                attention = Attention(2, 4, 0.5, 1)
+                attention.flash_attn_varlen_func = None
+                attention.flash_attn_with_kvcache = None
+                attention.use_triton_kv_cache = False
+                attention.k_cache = torch.empty(
+                    (1, 4, 1, 4),
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
+                attention.v_cache = torch.empty_like(attention.k_cache)
+
+                try:
+                    set_context(
+                        True,
+                        cu_seqlens_q=int_tensor([0, 3]),
+                        cu_seqlens_k=int_tensor([0, 3]),
+                        max_seqlen_q=3,
+                        max_seqlen_k=3,
+                        slot_mapping=int_tensor([0, 1, 2]),
+                    )
+                    prefill = attention(
+                        randn((3, 2, 4)),
+                        randn((3, 1, 4)),
+                        randn((3, 1, 4)),
+                    )
+                    self.assertEqual(prefill.dtype, torch.bfloat16)
+
+                    set_context(
+                        False,
+                        slot_mapping=int_tensor([3]),
+                        context_lens=int_tensor([4]),
+                        block_tables=int_tensor([[0]]),
+                    )
+                    decoded = attention(
+                        randn((1, 2, 4)),
+                        randn((1, 1, 4)),
+                        randn((1, 1, 4)),
+                    )
+                    self.assertEqual(decoded.dtype, torch.bfloat16)
+
+                    if device.type == "cuda":
+                        def graph_decode(q, k, v, slots, context_lens, blocks):
+                            set_context(
+                                False,
+                                slot_mapping=slots,
+                                context_lens=context_lens,
+                                block_tables=blocks,
+                            )
+                            return attention(q, k, v)
+
+                        runner = CUDAGraphRunner(
+                            "test:minimax_music3_kv_dtype",
+                            graph_decode,
+                        )
+                        try:
+                            graph_decoded = runner.run(
+                                randn((1, 2, 4)),
+                                randn((1, 1, 4)),
+                                randn((1, 1, 4)),
+                                int_tensor([3]),
+                                int_tensor([4]),
+                                int_tensor([[0]]),
+                            )
+                            torch.cuda.synchronize()
+                            self.assertEqual(
+                                graph_decoded.dtype,
+                                torch.bfloat16,
+                            )
+                            self.assertTrue(
+                                bool(torch.isfinite(graph_decoded).all())
+                            )
+                        finally:
+                            runner.release()
+                finally:
+                    reset_context()
 
     def test_settings_validation(self):
         handler = _load_handler_namespace()["family_handler"]


### PR DESCRIPTION
## Summary

- normalize Q, K, and V to the resident KV-cache dtype before non-Triton cache storage and SDPA
- keep the Triton KV-cache path unchanged
- add regression coverage for prefill, eager decode, and CUDA-graph decode

## Root cause

MiniMax Music 3 allocates its accelerated semantic KV cache in BF16 from the language-model dtype. On runtimes where Maestro's Triton INT8 kernel is unavailable, Quanto's fallback linear operation follows the checkpoint's FP32 quantization-scale dtype and returns FP32 Q/K/V tensors. Both `index_copy_` and indexed cache assignment reject an FP32 source for a BF16 cache.

Casting only K/V at the write site is insufficient: decode would then pass an FP32 query and BF16 cached K/V to SDPA, which also requires matching dtypes. Aligning all three tensors at the non-Triton attention boundary fixes both failures and preserves the intended BF16 cache footprint.

## Verification

- `python -m unittest discover -s tests`: **951 tests passed** on AMD Radeon AI PRO R9700 / ROCm
- focused MiniMax Music 3 regression passed on CPU and R9700
- R9700 regression covers Maestro's `CUDAGraphRunner` capture/replay path
- `git diff --check` passed
