### PR TITLE
Resume CivitAI downloads after temporary network failures

### DIFF
--- a/app/launch.py
+++ b/app/launch.py
@@ -62,6 +62,7 @@ from services.checkpoint_compatibility import (
     unsupported_checkpoint_reason,
     validate_checkpoint_file,
 )
+from services.resumable_download import ResumableDownload
 from services.generation_eta import AdaptiveGenerationEta, GenerationEtaHistory
 from services.remote_access import TailscaleManager
 from services.web_push import WebPushService, WebPushUnavailable
@@ -4146,6 +4147,7 @@ def _run_civitai_download(download_id: str):
     filename = dl["filename"]
     partial_paths = set()
     reserved_targets = set()
+    resp = None
 
     try:
         # CivitAI's download endpoint sits behind Cloudflare with bot
@@ -4192,22 +4194,12 @@ def _run_civitai_download(download_id: str):
                 sep = "&" if "?" in url else "?"
                 url = f"{url}{sep}token={api_key}"
                 headers["Authorization"] = f"Bearer {api_key}"
-        resp = requests.get(url, headers=headers, stream=True, timeout=30, allow_redirects=True)
-        if resp.status_code >= 400:
-            # Surface CivitAI's actual response body so we can tell whether
-            # it's a Cloudflare challenge, a token issue, an unauthorized
-            # error, etc. — invaluable for diagnosing 500s in the wild.
-            body_preview = ""
-            try:
-                body_preview = resp.text[:500] if hasattr(resp, "text") else ""
-            except Exception:
-                pass
-            print(
-                f"[CivitAI] Download HTTP {resp.status_code} for {url}\n"
-                f"  Response headers: {dict(resp.headers)}\n"
-                f"  Body preview: {body_preview!r}"
+        def report_retry(attempt, offset):
+            _update_download_record(
+                download_id,
+                message=f"Connection interrupted; resuming download (retry {attempt}/4)...",
             )
-        resp.raise_for_status()
+        resp = ResumableDownload(url, headers, on_retry=report_retry)
 
         # Get filename from content-disposition if available
         cd = resp.headers.get("content-disposition", "")
@@ -4402,6 +4394,8 @@ def _run_civitai_download(download_id: str):
         _fail_download_record(download_id, e)
         print(f"[CivitAI] Download failed: {e}")
     finally:
+        if resp is not None:
+            resp.close()
         for cleanup_path in tuple(partial_paths):
             try:
                 if os.path.isfile(cleanup_path):

--- a/app/services/resumable_download.py
+++ b/app/services/resumable_download.py
@@ -1,0 +1,114 @@
+"""Bounded retries and validated HTTP Range resumption for large downloads."""
+from __future__ import annotations
+
+import re
+import time
+
+import requests
+
+
+class ResumableDownload:
+    """One logical byte stream, reopening the original URL after interruptions.
+
+    Only identity-encoded responses can be resumed. If-Range and a matching
+    strong ETag (or Last-Modified) protect against combining different files.
+    The caller must close this object even when its consumer stops early.
+    """
+
+    def __init__(self, url, headers, *, on_retry=None, get=None, sleep=time.sleep, max_retries=4):
+        self.url = url
+        self.request_headers = {**headers, "Accept-Encoding": "identity"}
+        self.on_retry = on_retry
+        self.get = get or requests.get
+        self.sleep = sleep
+        self.max_retries = max_retries
+        self.retries = 0
+        self.response = None
+        self.offset = 0
+        self._open()
+        self.headers = self.response.headers
+        raw_total = self.headers.get("Content-Length", "")
+        self.total = int(raw_total) if str(raw_total).isdigit() else 0
+        self.validator_key = "ETag"
+        self.validator = self.headers.get("ETag", "")
+        if not self.validator or self.validator.startswith("W/"):
+            self.validator_key = "Last-Modified"
+            self.validator = self.headers.get("Last-Modified", "")
+
+    def _retry(self):
+        if self.retries >= self.max_retries:
+            raise RuntimeError(f"CivitAI download remained interrupted after {self.max_retries} automatic retries. Please retry later.") from None
+        self.retries += 1
+        if self.on_retry:
+            self.on_retry(self.retries, self.offset)
+        self.sleep(min(2 ** self.retries, 16))
+
+    def _open(self):
+        while True:
+            headers = dict(self.request_headers)
+            if self.offset:
+                headers.update({"Range": f"bytes={self.offset}-", "If-Range": self.validator})
+            try:
+                response = self.get(self.url, headers=headers, stream=True, timeout=(15, 60), allow_redirects=True)
+            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+                self._retry()
+                continue
+            if response.status_code in {408, 429, 500, 502, 503, 504}:
+                response.close()
+                self._retry()
+                continue
+            if response.status_code >= 400:
+                status = response.status_code
+                response.close()
+                raise RuntimeError(f"CivitAI download server returned HTTP {status}. Check access or retry later.")
+            if response.headers.get("Content-Encoding", "identity").lower() != "identity":
+                response.close()
+                raise RuntimeError("CivitAI returned a compressed download despite an identity request; byte-range resumption is unavailable.")
+            if not self.offset and response.status_code != 200:
+                response.close()
+                raise RuntimeError("CivitAI returned an unexpected partial response for a new download.")
+            self.response = response
+            return
+
+    def raise_for_status(self):
+        # _open already checks status, without exposing signed URLs or tokens.
+        return None
+
+    def iter_content(self, chunk_size=1024 * 1024):
+        while True:
+            try:
+                for chunk in self.response.iter_content(chunk_size=chunk_size):
+                    if not chunk:
+                        continue
+                    self.offset += len(chunk)
+                    if self.total and self.offset > self.total:
+                        raise RuntimeError("Download server sent more bytes than the declared file size.")
+                    yield chunk
+                if self.total and self.offset < self.total:
+                    raise requests.exceptions.ChunkedEncodingError("Incomplete response")
+                return
+            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError, requests.exceptions.ChunkedEncodingError):
+                self.close()
+                if self.offset and (not self.validator or not self.total):
+                    raise RuntimeError("CivitAI interrupted the download and supplied no file identity/size for safe resumption. Please retry.") from None
+                self._retry()
+                self._open()
+                if not self.offset:
+                    # No bytes escaped: allow the fresh response to establish identity.
+                    self.headers = self.response.headers
+                    raw_total = self.headers.get("Content-Length", "")
+                    self.total = int(raw_total) if str(raw_total).isdigit() else 0
+                    self.validator = self.headers.get(self.validator_key, "")
+                    continue
+                match = re.fullmatch(r"bytes (\d+)-(\d+)/(\d+)", self.response.headers.get("Content-Range", ""))
+                if (self.response.status_code != 206 or not match
+                    or int(match[1]) != self.offset or int(match[2]) != self.total - 1
+                    or int(match[3]) != self.total
+                    or self.response.headers.get(self.validator_key) != self.validator
+                    or self.response.headers.get("Content-Encoding", "identity") != "identity"):
+                    self.close()
+                    raise RuntimeError("CivitAI could not safely resume this file (changed file or unsupported byte range). Please retry.")
+
+    def close(self):
+        if self.response is not None:
+            self.response.close()

--- a/tests/test_resumable_download.py
+++ b/tests/test_resumable_download.py
@@ -1,0 +1,126 @@
+"""Network-free checks for exact, bounded CivitAI stream resumption."""
+import importlib.util
+import ast
+from pathlib import Path
+import unittest
+
+import requests
+
+spec = importlib.util.spec_from_file_location("resumable_download", Path(__file__).resolve().parents[1] / "app/services/resumable_download.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class Response:
+    def __init__(self, chunks=(), *, status=200, headers=None):
+        self.status_code = status
+        self.headers = requests.structures.CaseInsensitiveDict(headers or {})
+        self.chunks = chunks
+        self.closed = False
+
+    def iter_content(self, chunk_size):
+        for chunk in self.chunks:
+            if isinstance(chunk, Exception):
+                raise chunk
+            yield chunk
+
+    def close(self):
+        self.closed = True
+
+
+class TestResumableDownload(unittest.TestCase):
+    def download(self, responses, **kwargs):
+        calls = []
+        def get(url, **options):
+            calls.append((url, options))
+            response = responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+        return module.ResumableDownload("https://civitai.com/api/download/models/123", {}, get=get, sleep=lambda _: None, **kwargs), calls
+
+    def test_timeout_resumes_exact_bytes_and_refreshes_original_url(self):
+        first = Response([b"abc", requests.exceptions.ConnectionError("timeout")], headers={"Content-Length": "6", "ETag": '"v1"'})
+        second = Response([b"def"], status=206, headers={"Content-Range": "bytes 3-5/6", "ETag": '"v1"'})
+        download, calls = self.download([first, second])
+        try:
+            self.assertEqual(b"".join(download.iter_content()), b"abcdef")
+            self.assertTrue(first.closed)
+            self.assertEqual(calls[1][0], calls[0][0])
+            self.assertEqual(calls[1][1]["headers"]["Range"], "bytes=3-")
+            self.assertEqual(calls[1][1]["headers"]["If-Range"], '"v1"')
+            self.assertEqual(calls[0][1]["headers"]["Accept-Encoding"], "identity")
+        finally:
+            download.close()
+        self.assertTrue(second.closed)
+
+    def test_incomplete_clean_eof_also_resumes(self):
+        first = Response([b"abc"], headers={"Content-Length": "6", "Last-Modified": "date"})
+        second = Response([b"def"], status=206, headers={"Content-Range": "bytes 3-5/6", "Last-Modified": "date"})
+        download, _ = self.download([first, second])
+        self.assertEqual(b"".join(download.iter_content()), b"abcdef")
+        download.close()
+
+    def test_invalid_resume_is_rejected_without_appending(self):
+        for status, extra in ((200, {}), (206, {"ETag": '"changed"'}), (206, {"Content-Range": "bytes 0-5/6"}), (206, {"Content-Range": "bytes 3-8/9"})):
+            with self.subTest(status=status, extra=extra):
+                first = Response([b"abc", requests.exceptions.ReadTimeout()], headers={"Content-Length": "6", "ETag": '"v1"'})
+                second = Response([b"WRONG"], status=status, headers={"Content-Range": "bytes 3-5/6", "ETag": '"v1"', **extra})
+                download, _ = self.download([first, second])
+                stream = download.iter_content()
+                self.assertEqual(next(stream), b"abc")
+                with self.assertRaisesRegex(RuntimeError, "safely resume"):
+                    next(stream)
+                self.assertTrue(second.closed)
+
+    def test_retries_are_bounded_and_errors_do_not_expose_url(self):
+        with self.assertRaisesRegex(RuntimeError, "2 automatic retries") as caught:
+            self.download([requests.exceptions.ReadTimeout("SECRET")] * 3, max_retries=2)
+        self.assertNotIn("SECRET", str(caught.exception))
+
+    def test_transient_status_retries_but_auth_failure_does_not(self):
+        unavailable = Response(status=503)
+        download, calls = self.download([unavailable, Response([b"ok"], headers={"Content-Length": "2"})])
+        self.assertEqual(b"".join(download.iter_content()), b"ok")
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(unavailable.closed)
+        download.close()
+        with self.assertRaisesRegex(RuntimeError, "HTTP 403"):
+            self.download([Response(status=403)])
+
+    def test_missing_validator_and_weak_etag_do_not_mix_files(self):
+        for headers in ({"Content-Length": "6"}, {"Content-Length": "6", "ETag": 'W/"v1"'}):
+            download, calls = self.download([Response([b"abc", requests.exceptions.ReadTimeout()], headers=headers)])
+            with self.assertRaisesRegex(RuntimeError, "safe resumption"):
+                list(download.iter_content())
+            self.assertEqual(len(calls), 1)
+
+    def test_failure_before_first_byte_can_retry_without_range(self):
+        first = Response([requests.exceptions.ReadTimeout()])
+        second = Response([b"ok"], headers={"Content-Length": "2"})
+        download, calls = self.download([first, second])
+        self.assertEqual(b"".join(download.iter_content()), b"ok")
+        self.assertNotIn("Range", calls[1][1]["headers"])
+        download.close()
+
+    def test_worker_closes_download_on_success_or_consumer_failure(self):
+        source = (Path(__file__).resolve().parents[1] / "app/launch.py").read_text()
+        worker = next(node for node in ast.parse(source).body if isinstance(node, ast.FunctionDef) and node.name == "_run_civitai_download")
+        outer_try = next(node for node in worker.body if isinstance(node, ast.Try))
+        cleanup = ast.unparse(ast.Module(body=outer_try.finalbody, type_ignores=[]))
+        self.assertIn("if resp is not None:", cleanup)
+        self.assertIn("resp.close()", cleanup)
+
+    def test_encoding_and_oversized_response_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "compressed"):
+            self.download([Response(headers={"Content-Encoding": "gzip"})])
+        download, _ = self.download([Response([b"too long"], headers={"Content-Length": "2"})])
+        try:
+            with self.assertRaisesRegex(RuntimeError, "more bytes"):
+                list(download.iter_content())
+        finally:
+            download.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Large CivitAI downloads abort after a 30-second read timeout and discard all progress. A 20.96 GB FP8 H3 download repeatedly failed between 26% and 40%. This change retries temporary failures up to four times and resumes the existing byte stream instead of immediately failing the download.

The downloader reopens the original CivitAI URL to refresh CDN redirects and requests the remaining bytes with `Range` and `If-Range`. It requires a matching strong ETag or Last-Modified, total size, and exact Content-Range before appending bytes. Ignored ranges or changed files stop with a clear error. The read timeout is 60 seconds; temporary HTTP failures retry, access failures stop, and error messages omit signed URLs and credentials. Responses close on success and consumer failure. Existing final validation and atomic publication remain in place.

Retries preserve progress within the current attempt; partial files are still removed after exhausted retries or process-level cleanup. This does not add persistent resume across restarts.

Validation: 9 focused retry/stream tests, 14 download-state tests, and 14 checkpoint compatibility tests pass against upstream main. Required clean-repository, compileall, and React production-build checks pass. In the local installation, the 20.96 GB download continued after a stall around 60% and completed with successful model registration and no warnings; this observation does not independently establish how many retries occurred.

This PR targets upstream main independently of #100. The local installation also tested the retry stream with the early header validation introduced by #100.
