### PR TITLE
Fix LTX2 gated-attention dtype crash on voice-clone / ID-LoRA runs

### DIFF
--- a/app/models/ltx2/ltx_core/model/transformer/attention.py
+++ b/app/models/ltx2/ltx_core/model/transformer/attention.py
@@ -189,6 +189,16 @@ class Attention(torch.nn.Module):
 
         self.to_out = torch.nn.Sequential(torch.nn.Linear(inner_dim, query_dim, bias=True), torch.nn.Identity())
 
+    def _apply_gate(self, out: torch.Tensor, gate_input: torch.Tensor) -> None:
+        # `to_gate_logits` is excluded from quantization (see ltx2.py's exclusion
+        # list), so it stays bf16 while the surrounding linears are quanto int8.
+        # Those int8 layers only emit bf16 while the Triton kernels are injected;
+        # on the exact optimum.quanto path (voice-clone / ID-LoRA runs) they
+        # preserve the fp32 activations instead, so cast to the gate's own dtype.
+        gate_logits = self.to_gate_logits(gate_input.to(self.to_gate_logits.weight.dtype))
+        gates = 2.0 * torch.sigmoid(gate_logits).to(dtype=out.dtype)
+        out.mul_(gates.unsqueeze(-1))
+
     def _resolve_attention_override(self) -> tuple[str | None, int | None]:
         if isinstance(self.attention_function, AttentionFunction):
             if self.attention_function is AttentionFunction.PYTORCH:
@@ -273,9 +283,7 @@ class Attention(torch.nn.Module):
                 out.add_(x_pos)
                 x_pos = None
                 if self.to_gate_logits is not None:
-                    gate_logits = self.to_gate_logits(gate_input)
-                    gates = 2.0 * torch.sigmoid(gate_logits).to(dtype=out.dtype)
-                    out.mul_(gates.unsqueeze(-1))
+                    self._apply_gate(out, gate_input)
                 gate_input = None
                 out = out.flatten(2, 3)
                 out = self.to_out(out)
@@ -291,9 +299,7 @@ class Attention(torch.nn.Module):
             recycle_q= True,
         )
         if self.to_gate_logits is not None:
-            gate_logits = self.to_gate_logits(gate_input)
-            gates = 2.0 * torch.sigmoid(gate_logits).to(dtype=out.dtype)
-            out.mul_(gates.unsqueeze(-1))
+            self._apply_gate(out, gate_input)
         gate_input = None
         out = out.flatten(2, 3)
         out = self.to_out(out)

--- a/tests/test_ltx2_attention_gate_dtype.py
+++ b/tests/test_ltx2_attention_gate_dtype.py
@@ -1,0 +1,81 @@
+"""Regression checks for LTX2 gated attention under mixed activation dtypes.
+
+`to_gate_logits` is on the LTX2 never-quantize list, so it stays bf16 while the
+surrounding projections are quanto int8. The injected Triton int8 kernels emit
+bf16 activations, but the exact optimum.quanto path used by voice-clone /
+ID-LoRA runs preserves fp32 ones, which previously crashed the gate projection
+with "mat1 and mat2 must have the same dtype".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_APP = os.path.join(_ROOT, "app")
+if _APP not in sys.path:
+    sys.path.insert(0, _APP)
+
+
+class TestGatedAttentionMixedDtype(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import torch
+
+            from models.ltx2.ltx_core.model.transformer.attention import (
+                Attention,
+                AttentionFunction,
+            )
+        except Exception as exc:
+            raise unittest.SkipTest(f"LTX2 attention dependencies unavailable: {exc}") from exc
+        cls.torch = torch
+        cls.Attention = Attention
+        cls.AttentionFunction = AttentionFunction
+
+    def _build(self):
+        """fp32 projections with a bf16 gate — the quanto int8 layout."""
+        attn = self.Attention(
+            query_dim=64,
+            context_dim=64,
+            heads=4,
+            dim_head=16,
+            apply_gated_attention=True,
+            attention_function=self.AttentionFunction.PYTORCH,
+        ).to(self.torch.float32)
+        attn.eval()
+        attn.to_gate_logits.to(self.torch.bfloat16)
+        return attn
+
+    def test_self_attention_gate_accepts_fp32_activations(self):
+        attn = self._build()
+        x = self.torch.randn(1, 8, 64)
+        with self.torch.no_grad():
+            out = attn([x])
+        self.assertEqual(out.shape, (1, 8, 64))
+        self.assertEqual(out.dtype, self.torch.float32)
+
+    def test_nag_cross_attention_gate_accepts_fp32_activations(self):
+        attn = self._build()
+        x = self.torch.randn(1, 8, 64)
+        context = self.torch.randn(1, 12, 64)
+        nag = {"cap_embed_len": 6, "scale": 1.5, "alpha": 0.5, "tau": 2.5}
+        with self.torch.no_grad():
+            out = attn([x], context_list=[context], NAG=nag)
+        self.assertEqual(out.shape, (1, 8, 64))
+        self.assertEqual(out.dtype, self.torch.float32)
+
+    def test_gate_still_works_when_dtypes_already_match(self):
+        attn = self._build()
+        attn.to_gate_logits.to(self.torch.float32)
+        x = self.torch.randn(1, 8, 64)
+        with self.torch.no_grad():
+            out = attn([x])
+        self.assertEqual(out.dtype, self.torch.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

Any LTX2 generation with a voice reference and `identity_guidance_scale > 0` dies during prompt encoding:

```
File "app/models/ltx2/ltx_core/model/transformer/attention.py", line 294, in forward
  gate_logits = self.to_gate_logits(gate_input)
RuntimeError: mat1 and mat2 must have the same dtype, but got Float and BFloat16
```

## Why

`to_gate_logits` is on the LTX2 never-quantize list (`ltx2.py:101`), so it stays bf16 while the surrounding projections in the Gemma embeddings connector are quanto int8.

Normally that mismatch is invisible. With the Triton int8 kernels injected, `_resolve_output_dtype` (`shared/kernels/quanto_int8_inject.py:369`) forces every quantized linear to emit the weight-scale dtype — bf16 — so the gate projection always sees bf16 activations.

Voice-clone / ID-LoRA runs deliberately tear that out (`ltx2.py:2437-2453`) and restore the stock `optimum.quanto` forward, to stay symbol-identical to upstream Wan2GP. Stock `qbytes_mm` preserves the *input* dtype instead, and the int8 ConvRot Gemma checkpoint emits fp32 hidden states. So the connector reaches the bf16 gate projection with fp32 activations and crashes.

The two paths disagree about activation dtype; the gate projection is the only layer that cares.

## The fix

Cast the gate input to the projection's own dtype. `gates` was already cast back to `out.dtype` on the very next line, so nothing downstream changes — this is dtype plumbing, not a numerics change. Both call sites (plain self-attention and the NAG cross-attention branch) now share one `_apply_gate` helper so the two copies cannot drift.

## Testing

New `tests/test_ltx2_attention_gate_dtype.py` builds an `Attention` in the quanto layout (fp32 projections, bf16 gate) and exercises both branches.

- Reverting only the `attention.py` change reproduces the exact `mat1 and mat2 must have the same dtype` error in 2 of the 3 tests.
- With the fix, all 3 pass.
- It skips cleanly when torch is unavailable, matching `test_attention_runtime.py`, so it is a no-op on the CI runner.

Also green locally: `test_ltx25_integration.py` (24), `test_ltx_multi_window.py` (19), `test_attention_runtime.py`, plus `scripts/verify_clean_repo.py`, `compileall`, and `ruff --select F821,F823`.

Not covered: a full end-to-end voice-clone generation on hardware — the fix is verified at the unit level against a faithful reproduction of the failing layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
